### PR TITLE
Visualize results

### DIFF
--- a/estimation.R
+++ b/estimation.R
@@ -414,7 +414,7 @@ mukf_computation = function(I, infectivity, par1, par2, par3, skip_initial = 4){
     R_hat=R_hat,
     a=a,
     P=P,
-    alpha_hat=a,
+    alpha=do.call(Map, c(f = c, a)),
     logLikelihood=logLikelihood
   ))
 }

--- a/simulation-study/error_analysis.R
+++ b/simulation-study/error_analysis.R
@@ -1,0 +1,82 @@
+"
+Visualize the internal parameters of a fitted Kalman filter from performed tests
+(from `simulation-study/run.R`).
+"
+library(RJSONIO)
+library(EpiEstim)
+library(ggplot2)
+library(cowplot)
+
+RESULT_ID = readline("Result set ID (looks like `202201050426`): ")
+CONFIG_FILE = "./simulation-study/config.json"
+RESULTS_FILE = file.path("./simulation-study/results", paste0(RESULT_ID, ".json"))
+OUTPUT_DIR = file.path("./simulation-study/error-analysis", RESULT_ID)
+config = fromJSON(CONFIG_FILE)
+results = fromJSON(RESULTS_FILE)
+dir.create(OUTPUT_DIR, recursive=TRUE)
+
+# Read the results of a random simulation
+esimation_results = results[[1]]$epidemic_results[[1]]$raw_output
+epidemic_results = results[[1]]$epidemic_results[[1]]
+M = unlist(epidemic_results$M)
+
+# Construct dataframe with series to be visualized
+R = config$scenarios[[1]]$R
+plot_df = data.frame(R)
+plot_df$t = 1:nrow(plot_df)
+# R_hat
+R_hat = esimation_results$ekf$R_hat
+R_hat[sapply(R_hat, is.null)] = NA
+plot_df$R_hat = unlist(R_hat)
+# exp(alpha_1)
+alpha_1 = lapply(esimation_results$ekf$alpha, function(x) x[1])
+alpha_1[sapply(alpha_1, is.null)] = NA
+plot_df$`exp(alpha_1)` = exp(unlist(alpha_1))
+# M_hat
+M_hat = lapply(esimation_results$ekf$alpha, function(x) x[2])
+M_hat[sapply(M_hat, is.null)] = NA
+plot_df$`M_hat` = exp(unlist(M_hat))
+# exp(alpha_3)
+alpha_3 = lapply(esimation_results$ekf$alpha, function(x) x[3])
+alpha_3[sapply(alpha_3, is.null)] = NA
+plot_df$`exp(alpha_3)` = exp(unlist(alpha_3))
+# Ground truth
+plot_df$M = tail(M, length(R))
+plot_df$I = epidemic_results$I
+plot_df$XI = tail(epidemic_results$XI, length(R))
+# Plot 1: Incidence series
+I_plot = ggplot(plot_df, aes(x=t)) +
+  geom_line(aes(y=I, color="I")) +
+  geom_line(aes(y=XI, color="XI")) +
+  scale_colour_manual(
+    values = c(
+      "I" = "black",
+      "XI" = "blue"
+    )
+  )
+# Plot 2: R_hat = exp(alpha_1)
+R_hat_plot = ggplot(plot_df, aes(x=t)) +
+  geom_line(aes(y=R, linetype="Ground Truth")) +
+  geom_line(aes(y=R_hat, linetype="Smoothed")) +
+  ylim(0, max(plot_df$R * 2))
+  scale_linetype_manual(
+    values = c(
+      "Ground Truth" = 1,
+      "Smoothed" = 2
+    )
+  )
+# Plot 3: M_hat = exp(alpha_2)
+M_hat_plot = ggplot(plot_df, aes(x=t)) +
+  geom_line(aes(y=M, linetype="Ground Truth"), color="blue") +
+  geom_line(aes(y=M_hat, linetype="Smoothed"), color="blue") +
+  scale_linetype_manual(
+    values = c(
+      "Ground Truth" = 1,
+      "Smoothed" = 2
+    )
+  )
+# Plot 4: R_hat derivative = exp(alpha_3)
+alpha_3_plot = ggplot(plot_df, aes(x=t)) +
+  geom_line(aes(y=`exp(alpha_3)`), color="purple", linetype=2)
+# Draw all plots in a single frame
+plot_grid(I_plot, R_hat_plot, M_hat_plot, alpha_3_plot, ncol=1, axis="lr", align="v")

--- a/simulation-study/error_analysis.R
+++ b/simulation-study/error_analysis.R
@@ -1,82 +1,134 @@
-"
-Visualize the internal parameters of a fitted Kalman filter from performed tests
-(from `simulation-study/run.R`).
-"
+# Visualize the internal parameters of a fitted Kalman filter from performed tests
+# (from `simulation-study/run.R`).
+
 library(RJSONIO)
 library(EpiEstim)
+library(comprehenr)
 library(ggplot2)
+library(RColorBrewer)
 library(cowplot)
+library(argparse)
 
-RESULT_ID = readline("Result set ID (looks like `202201050426`): ")
 CONFIG_FILE = "./simulation-study/config.json"
-RESULTS_FILE = file.path("./simulation-study/results", paste0(RESULT_ID, ".json"))
-OUTPUT_DIR = file.path("./simulation-study/error-analysis", RESULT_ID)
+COLORS = brewer.pal(name = "Dark2", n=8)
+ALGORITHM_COLOR_MAP = list(
+  "ekf"=COLORS[1],
+  "mukf"=COLORS[2]
+)
+
+parser = ArgumentParser(description="Plot error analysis for a result set")
+parser$add_argument("result_id", help="Result set ID (looks like `202201050426`)")
+cl_args = parser$parse_args()
+result_id = cl_args$result_id
+results_file = file.path("./simulation-study/results", paste0(result_id, ".json"))
+output_dir = file.path("./simulation-study/error-analysis", result_id)
 config = fromJSON(CONFIG_FILE)
-results = fromJSON(RESULTS_FILE)
-dir.create(OUTPUT_DIR, recursive=TRUE)
+results = fromJSON(results_file)
 
 # Read the results of a random simulation
-esimation_results = results[[1]]$epidemic_results[[1]]$raw_output
-epidemic_results = results[[1]]$epidemic_results[[1]]
-M = unlist(epidemic_results$M)
+algorithm = "ekf"
+scenario_results = results[[1]]
+scenario_config = config$scenarios[[1]]
 
-# Construct dataframe with series to be visualized
-R = config$scenarios[[1]]$R
-plot_df = data.frame(R)
-plot_df$t = 1:nrow(plot_df)
-# R_hat
-R_hat = esimation_results$ekf$R_hat
-R_hat[sapply(R_hat, is.null)] = NA
-plot_df$R_hat = unlist(R_hat)
-# exp(alpha_1)
-alpha_1 = lapply(esimation_results$ekf$alpha, function(x) x[1])
-alpha_1[sapply(alpha_1, is.null)] = NA
-plot_df$`exp(alpha_1)` = exp(unlist(alpha_1))
-# M_hat
-M_hat = lapply(esimation_results$ekf$alpha, function(x) x[2])
-M_hat[sapply(M_hat, is.null)] = NA
-plot_df$`M_hat` = exp(unlist(M_hat))
-# exp(alpha_3)
-alpha_3 = lapply(esimation_results$ekf$alpha, function(x) x[3])
-alpha_3[sapply(alpha_3, is.null)] = NA
-plot_df$`exp(alpha_3)` = exp(unlist(alpha_3))
-# Ground truth
-plot_df$M = tail(M, length(R))
-plot_df$I = epidemic_results$I
-plot_df$XI = tail(epidemic_results$XI, length(R))
-# Plot 1: Incidence series
-I_plot = ggplot(plot_df, aes(x=t)) +
-  geom_line(aes(y=I, color="I")) +
-  geom_line(aes(y=XI, color="XI")) +
-  scale_colour_manual(
-    values = c(
-      "I" = "black",
-      "XI" = "blue"
+for (scenario_idx in 1:length(config$scenarios)) {
+  scenario_results = results[[scenario_idx]]
+  scenario_config = config$scenarios[[scenario_idx]]
+  scenario_output_dir = file.path(output_dir, paste0("scenario", scenario_idx))
+  dir.create(scenario_output_dir, recursive=TRUE)
+  for (algorithm in c("ekf", "mukf")) {
+    # Construct dataframe with series to be visualized
+    plot_df = data.frame(
+      "ID" = "Ground Truth",
+      "t" = 1:config$T,
+      "I" = rep(NA, config$T),
+      "XI" = rep(NA, config$T),
+      "M" = rep(NA, config$T),
+      "R_hat" = scenario_config$R,
+      "M_hat" = rep(NA, config$T)
     )
-  )
-# Plot 2: R_hat = exp(alpha_1)
-R_hat_plot = ggplot(plot_df, aes(x=t)) +
-  geom_line(aes(y=R, linetype="Ground Truth")) +
-  geom_line(aes(y=R_hat, linetype="Smoothed")) +
-  ylim(0, max(plot_df$R * 2))
-  scale_linetype_manual(
-    values = c(
-      "Ground Truth" = 1,
-      "Smoothed" = 2
+    epidemic_idx = 1
+    for (epidemic_result in scenario_results$epidemic_results) {
+      # Format estimation result
+      estimation_result = epidemic_result$raw_output[[algorithm]]
+      R_hat = estimation_result$R_hat
+      R_hat[sapply(R_hat, is.null)] = NA
+      R_hat = unlist(R_hat)
+      alpha_2 = lapply(estimation_result$alpha, function(x) x[2])
+      alpha_2[sapply(alpha_2, is.null)] = NA
+      M_hat = exp(unlist(alpha_2))
+      M = epidemic_result$M
+      M[sapply(M, is.null)] = NA
+      M = unlist(M)
+      epidemic_df = data.frame(
+        "ID" = paste("Epidemic", epidemic_idx),
+        "t" = 1:config$T,
+        "I" = epidemic_result$I,
+        "XI" = tail(epidemic_result$XI, config$T),
+        "M" = tail(M, config$T),
+        "R_hat" = R_hat,
+        "M_hat" = M_hat
+      )
+      # Append epidemic results to full results
+      plot_df = rbind(plot_df, epidemic_df)
+      epidemic_idx = epidemic_idx + 1
+    }
+    
+    # Plot 1: Incidence series
+    I_plot = ggplot(plot_df) +
+      geom_line(data=plot_df, aes(x=t, y=I, color="I", alpha="I", group=ID)) +
+      geom_line(data=plot_df, aes(x=t, y=XI, color="XI", alpha="XI", group=ID)) +
+      ylab("Incidence") +
+      scale_colour_manual(
+        name="Label",
+        values=c("I"="black", "XI"="blue"),
+        labels=c("I"="Local", "XI"="Immigrant")
+      ) +
+      scale_alpha_manual(
+        values=c("I"=0.3, "XI"=0.3),
+        guide="none"
+      )
+    
+    # Plot 2: R_hat = exp(alpha_1)
+    plot_df$is_ground_truth = plot_df$ID == "Ground Truth"
+    plot_df$is_ground_truth = sapply(plot_df$is_ground_truth, toString)
+    R_plot = ggplot(plot_df) +
+      geom_line(data=plot_df, aes(x=t, y=R_hat, color=is_ground_truth, alpha=is_ground_truth, group=ID)) +
+      ylab("R") +
+      ylim(min(scenario_config$R) / 4, max(scenario_config$R) * 2) +
+      scale_colour_manual(
+        name="Label",
+        values=c("TRUE"="black", "FALSE"=ALGORITHM_COLOR_MAP[[algorithm]]),
+        labels=c("TRUE"="Ground Truth", "FALSE"=algorithm)
+      ) +
+      scale_alpha_manual(
+        values=c("TRUE"=1, "FALSE"=0.3),
+        guide="none"
+      )
+    
+    # Plot 3: M_hat = exp(alpha_2)
+    M_plot = ggplot(plot_df) +
+      geom_line(data=plot_df, aes(x=t, y=M, color="Ground Truth", alpha="Ground Truth", group=ID)) +
+      geom_line(data=plot_df, aes(x=t, y=M_hat, color="Estimation", alpha="Estimation", group=ID)) +
+      ylab("M") +
+      ylim(min(plot_df$M, na.rm=TRUE) / 4, max(plot_df$M, na.rm=TRUE) * 1.3) +
+      scale_colour_manual(
+        name="Label",
+        values=c("Ground Truth"="black", "Estimation"=ALGORITHM_COLOR_MAP[[algorithm]]),
+        labels=c("Ground Truth"="Ground Truth", "Estimation"=algorithm)
+      ) +
+      scale_alpha_manual(
+        values=c("Ground Truth"=0.3, "Estimation"=0.3),
+        guide="none"
+      )
+    
+    # Draw all plots in a single frame
+    stacked_plot_path = file.path(
+      scenario_output_dir,
+      paste0(scenario_config$label, "-", algorithm, ".png")
     )
-  )
-# Plot 3: M_hat = exp(alpha_2)
-M_hat_plot = ggplot(plot_df, aes(x=t)) +
-  geom_line(aes(y=M, linetype="Ground Truth"), color="blue") +
-  geom_line(aes(y=M_hat, linetype="Smoothed"), color="blue") +
-  scale_linetype_manual(
-    values = c(
-      "Ground Truth" = 1,
-      "Smoothed" = 2
-    )
-  )
-# Plot 4: R_hat derivative = exp(alpha_3)
-alpha_3_plot = ggplot(plot_df, aes(x=t)) +
-  geom_line(aes(y=`exp(alpha_3)`), color="purple", linetype=2)
-# Draw all plots in a single frame
-plot_grid(I_plot, R_hat_plot, M_hat_plot, alpha_3_plot, ncol=1, axis="lr", align="v")
+    stacked_plot = plot_grid(I_plot, R_plot, M_plot, ncol=1, axis="lr", align="v")
+    png(stacked_plot_path, pointsize=15, width=500, height=600)
+    print(stacked_plot)
+    dev.off()
+  }
+}

--- a/simulation-study/run.R
+++ b/simulation-study/run.R
@@ -34,7 +34,7 @@ discrete_si = discretize_dist(
   n_vals = config$T + 3
 )
 # Simulate multiple epidemics per scenario
-results = list(discrete_si=discrete_si)
+results = list()
 for (scenario in config$scenarios) {
   print(paste("Simulating epidemics for scenario", scenario$id))
   scenario_start_time = Sys.time()
@@ -102,6 +102,7 @@ for (scenario in config$scenarios) {
   print(paste("Processing scenario", scenario$id, "took",
         round(scenario_total_time / 3600, digits=2), "hours"))
 }
+results$discrete_si = discrete_si
 # Write results to disk
 dir.create(OUT_DIR, recursive=TRUE)
 timestamp = format(Sys.time(), "%Y%m%d%H%M")

--- a/simulation-study/run.R
+++ b/simulation-study/run.R
@@ -36,6 +36,8 @@ discrete_si = discretize_dist(
 # Simulate multiple epidemics per scenario
 results = list()
 for (scenario in config$scenarios) {
+  print(paste("Simulating epidemics for scenario", scenario$id))
+  scenario_start_time = Sys.time()
   scenario_results = list(
     mean_mape = list(),
     epidemic_results = list()
@@ -53,7 +55,7 @@ for (scenario in config$scenarios) {
       R = scenario$R
     )
     infectivity = overall_infectivity(simulation$I, c(0, discrete_si))
-    # Estimate R using each of the available algorithmsç
+    # Estimate R using each of the available algorithms
     simulation_results = list(
       I = simulation$I,
       XI = simulation$XI,
@@ -63,13 +65,20 @@ for (scenario in config$scenarios) {
     for (estimator_name in names(ESTIMATORS)) {
       # Estimate R_hat
       estimator = ESTIMATORS[[estimator_name]]
-      simulation_results$R_hat[[estimator_name]] = estimator(
+      if (estimator_name %in% c("ekf", "mukf")) {
+        skip_initial = 2
+      } else {
+        skip_initial = 0
+      }
+      estimation_results = estimator(
         I = simulation$I,
         XI = simulation$XI,
         discrete_si = discrete_si,
         infectivity = infectivity,
-        skip_initial = config$mape_starts_at - 1
-      )$R_hat
+        skip_initial = skip_initial
+      )
+      simulation_results$R_hat[[estimator_name]] = estimation_results$R_hat
+      simulation_results$raw_output[[estimator_name]] = estimation_results
       simulation_results$mape[[estimator_name]] = mape(
         scenario$R,
         simulation_results$R_hat[[estimator_name]],
@@ -88,6 +97,9 @@ for (scenario in config$scenarios) {
   )
   results[[scenario$id]] = scenario_results
   results[[scenario$id]][["scenario_id"]] = scenario$id
+  scenario_total_time = Sys.time() - scenario_start_time
+  print(paste("Processing scenario", scenario$id, "took",
+        round(scenario_total_time / 3600, digits=2), "hours"))
 }
 # Write results to disk
 dir.create(OUT_DIR, recursive=TRUE)

--- a/simulation-study/run.R
+++ b/simulation-study/run.R
@@ -34,7 +34,7 @@ discrete_si = discretize_dist(
   n_vals = config$T + 3
 )
 # Simulate multiple epidemics per scenario
-results = list()
+results = list(discrete_si=discrete_si)
 for (scenario in config$scenarios) {
   print(paste("Simulating epidemics for scenario", scenario$id))
   scenario_start_time = Sys.time()
@@ -59,6 +59,7 @@ for (scenario in config$scenarios) {
     simulation_results = list(
       I = simulation$I,
       XI = simulation$XI,
+      M = overall_infectivity(simulation$XI, c(0, discrete_si)),
       R_hat = list(),
       mape = list()
     )


### PR DESCRIPTION
- Normalize how ekf and mukf return internals.
- Store more internal information in results (`discrete_si` and `M` series).
- Plot alpha values for ekf and mukf vs ground truth.
![Constant R, no immigration-mukf](https://user-images.githubusercontent.com/50839826/149666245-985db861-2fb1-4ef6-8957-9d947b9ce686.png)
